### PR TITLE
Swagger와 연관된 버그 수정

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -44,5 +44,6 @@ jobs:
           min-coverage-overall: 40
           min-coverage-changed-files: 60
           update-comment: true
+          title: Test Coverage
           pass-emoji: ':green_circle:'
           fail-emoji: ':red_circle:'

--- a/src/main/java/com/stream/configuration/HttpMsgConverterConfig.java
+++ b/src/main/java/com/stream/configuration/HttpMsgConverterConfig.java
@@ -1,0 +1,43 @@
+package com.stream.configuration;
+
+import java.lang.reflect.Type;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+public class HttpMsgConverterConfig {
+	@Bean
+	public AbstractJackson2HttpMessageConverter abstractJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+		return new MultipartJackson2HttpMessageConverter(objectMapper);
+	}
+
+	private class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+		/**
+		 * "Content-Type: multipart/form-data" 헤더를 지원하는 HTTP 요청 변환기
+		 */
+		public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+			super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+		}
+
+		@Override
+		public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+			return false;
+		}
+
+		@Override
+		public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+			return false;
+		}
+
+		@Override
+		protected boolean canWrite(MediaType mediaType) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/com/stream/controller/UploadController.java
+++ b/src/main/java/com/stream/controller/UploadController.java
@@ -25,7 +25,7 @@ public class UploadController {
 		this.securityContextHelper = securityContextHelper;
 	}
 
-	@PostMapping(path = "/videos/upload")
+	@PostMapping(path = "/videos/upload", consumes = "multipart/form-data")
 	public ResponseEntity uploadVideo(@Valid @RequestPart(value = "videoMetadata") UploadVideoRequest request,
 		@RequestPart(value = "videoFile") MultipartFile videoFile) {
 		var member = securityContextHelper.getMember();

--- a/src/main/java/com/stream/controller/VideoController.java
+++ b/src/main/java/com/stream/controller/VideoController.java
@@ -3,7 +3,7 @@ package com.stream.controller;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.stream.controller.dto.video.GetVideoResponse;
@@ -25,8 +25,8 @@ public class VideoController {
 			.body(ListVideoResponse.create(videoService.listVideo()));
 	}
 
-	@GetMapping(path = "/videos", params = "id")
-	public ResponseEntity<GetVideoResponse> getVideo(@RequestParam long id) {
+	@GetMapping(path = "/videos/{id}")
+	public ResponseEntity<GetVideoResponse> getVideo(@PathVariable long id) {
 		return ResponseEntity.ok()
 			.body(GetVideoResponse.convertDtoToResponse(videoService.getVideoMetadata(id)));
 

--- a/src/test/java/com/stream/controller/LoginControllerTest.java
+++ b/src/test/java/com/stream/controller/LoginControllerTest.java
@@ -28,13 +28,15 @@ public class LoginControllerTest {
 	private final MockMvc mockMvc;
 	private final TestHelper testHelper;
 	private final SignupFacade signupFacade;
+	private final ObjectMapper objectMapper;
 
 	@Autowired
 	public LoginControllerTest(MockMvc mockMvc, TestHelper testHelper,
-		SignupFacade signupFacade) {
+		SignupFacade signupFacade, ObjectMapper objectMapper) {
 		this.mockMvc = mockMvc;
 		this.testHelper = testHelper;
 		this.signupFacade = signupFacade;
+		this.objectMapper = objectMapper;
 	}
 
 	@BeforeEach
@@ -91,7 +93,7 @@ public class LoginControllerTest {
 	}
 
 	private RequestBuilder buildLoginApiReq(String email, String password) throws Exception {
-		String content = new ObjectMapper().writeValueAsString(
+		String content = objectMapper.writeValueAsString(
 			LoginRequest.builder().email(email).inputPassword(password).build());
 		return MockMvcRequestBuilders.post("/login").contentType(MediaType.APPLICATION_JSON).content(content);
 	}

--- a/src/test/java/com/stream/controller/SignupControllerTest.java
+++ b/src/test/java/com/stream/controller/SignupControllerTest.java
@@ -24,11 +24,13 @@ import com.stream.util.TestHelper;
 public class SignupControllerTest {
 	private final MockMvc mockMvc;
 	private final TestHelper testHelper;
+	private final ObjectMapper objectMapper;
 
 	@Autowired
-	public SignupControllerTest(MockMvc mockMvc, TestHelper testHelper) {
+	public SignupControllerTest(MockMvc mockMvc, TestHelper testHelper, ObjectMapper objectMapper) {
 		this.mockMvc = mockMvc;
 		this.testHelper = testHelper;
+		this.objectMapper = objectMapper;
 	}
 
 	@BeforeEach
@@ -69,7 +71,7 @@ public class SignupControllerTest {
 	}
 
 	private RequestBuilder buildSignupApiReq(String email, String password) throws Exception {
-		String content = new ObjectMapper().writeValueAsString(
+		String content = objectMapper.writeValueAsString(
 			SignupRequest.builder().email(email).inputPassword(password).build());
 		return MockMvcRequestBuilders.post("/sign-up")
 			.contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/stream/controller/VideoControllerTest.java
+++ b/src/test/java/com/stream/controller/VideoControllerTest.java
@@ -105,8 +105,7 @@ public class VideoControllerTest {
 		// given
 		initVideoTable(List.of("video_sample"));
 		// when
-		mockMvc.perform(MockMvcRequestBuilders.get("/videos")
-				.param("id", String.valueOf(1)))
+		mockMvc.perform(MockMvcRequestBuilders.get("/videos/" + 1))
 			// then
 			.andExpect(MockMvcResultMatchers.status().isForbidden());
 	}
@@ -122,9 +121,8 @@ public class VideoControllerTest {
 		var cookie = signupAndLoginAndExtractCookie(mockEmail, mockPwd);
 
 		// when
-		mockMvc.perform(MockMvcRequestBuilders.get("/videos")
-				.cookie(cookie)
-				.param("id", String.valueOf((video.getId() + 1))))
+		mockMvc.perform(MockMvcRequestBuilders.get("/videos/" + (video.getId() + 1))
+				.cookie(cookie))
 			// then
 			.andExpect(MockMvcResultMatchers.status().isNotFound());
 	}
@@ -140,9 +138,8 @@ public class VideoControllerTest {
 		var cookie = signupAndLoginAndExtractCookie(mockEmail, mockPwd);
 
 		// when
-		mockMvc.perform(MockMvcRequestBuilders.get("/videos")
-				.cookie(cookie)
-				.param("id", String.valueOf(video.getId())))
+		mockMvc.perform(MockMvcRequestBuilders.get("/videos/" + video.getId())
+				.cookie(cookie))
 			// then
 			.andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
 			.andDo(result -> {

--- a/src/test/java/com/stream/controller/VideoControllerTest.java
+++ b/src/test/java/com/stream/controller/VideoControllerTest.java
@@ -41,16 +41,18 @@ public class VideoControllerTest {
 	private final VideoService videoService;
 	private final LoginFacade loginFacade;
 	private final SignupFacade signupFacade;
+	private final ObjectMapper objectMapper;
 
 	@Autowired
 	public VideoControllerTest(MockMvc mockMvc, TestHelper testHelper,
 		VideoService videoService,
-		LoginFacade loginFacade, SignupFacade signupFacade) {
+		LoginFacade loginFacade, SignupFacade signupFacade, ObjectMapper objectMapper) {
 		this.mockMvc = mockMvc;
 		this.testHelper = testHelper;
 		this.videoService = videoService;
 		this.loginFacade = loginFacade;
 		this.signupFacade = signupFacade;
+		this.objectMapper = objectMapper;
 	}
 
 	@BeforeEach
@@ -92,7 +94,7 @@ public class VideoControllerTest {
 			.andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
 			.andDo(result -> {
 				String contentString = result.getResponse().getContentAsString();
-				ListVideoResponse response = new ObjectMapper().readValue(contentString, ListVideoResponse.class);
+				ListVideoResponse response = objectMapper.readValue(contentString, ListVideoResponse.class);
 				Assertions.assertThat(response)
 					.isEqualTo(
 						ListVideoResponse.create(videosInTable.stream().map(VideoDto::convertDomainToDto).toList()));
@@ -143,7 +145,7 @@ public class VideoControllerTest {
 			// then
 			.andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
 			.andDo(result -> {
-				GetVideoResponse videoResponse = new ObjectMapper().readValue(result.getResponse().getContentAsString(),
+				GetVideoResponse videoResponse = objectMapper.readValue(result.getResponse().getContentAsString(),
 					GetVideoResponse.class);
 				Assertions.assertThat(videoResponse)
 					.isEqualTo(GetVideoResponse.convertDtoToResponse(VideoDto.convertDomainToDto(video)));


### PR DESCRIPTION
- Header를 통한 엔드포인트 구분이 Swagger에서 적용되지 않는 문제 
  - PathVariable로 수정 `videos/{id}`
- 비디오 업로드 엔드포인트를 Swagger에서 요청할 때 `Content-Type 'application/octet-stream' is not supported.` 에러가 발생하는 문제
  - ref: https://stackoverflow.com/questions/16230291/requestpart-with-mixed-multipart-request-spring-mvc-3-2